### PR TITLE
test: add unit tests for core functions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=7.0.0
+pytest-mock>=3.10.0
+pytest-cov>=4.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Shared test fixtures for spotify-playlist-creator tests."""
+
+import pytest
+
+
+@pytest.fixture
+def mock_spotify_track():
+    """Factory for creating mock Spotify track objects.
+
+    Returns a function that creates track dictionaries matching
+    the Spotify API response structure.
+    """
+    def _create(
+        name,
+        artist,
+        album="Test Album",
+        popularity=50,
+        track_id="abc123"
+    ):
+        return {
+            "id": track_id,
+            "name": name,
+            "artists": [{"name": artist}],
+            "album": {"name": album},
+            "popularity": popularity
+        }
+    return _create
+
+
+@pytest.fixture
+def mock_search_response():
+    """Factory for creating mock sp.search() responses.
+
+    Returns a function that wraps a list of tracks in the
+    Spotify search response structure.
+    """
+    def _create(tracks):
+        return {"tracks": {"items": tracks}}
+    return _create

--- a/tests/test_parse_tsv.py
+++ b/tests/test_parse_tsv.py
@@ -1,0 +1,131 @@
+"""Tests for parse_tsv() function."""
+
+import pytest
+
+from spotify_playlist import parse_tsv
+
+
+class TestParseTsvErrors:
+    """Test error handling in parse_tsv()."""
+
+    def test_file_not_found(self):
+        """parse_tsv exits with code 1 when file does not exist."""
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv("/nonexistent/path/to/file.tsv")
+        assert exc_info.value.code == 1
+
+    def test_empty_file(self, tmp_path):
+        """parse_tsv exits with code 1 for empty file."""
+        tsv_file = tmp_path / "empty.tsv"
+        tsv_file.write_text("")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+    def test_header_only(self, tmp_path):
+        """parse_tsv exits with code 1 when file contains only header row."""
+        tsv_file = tmp_path / "header_only.tsv"
+        tsv_file.write_text("Title\tArtist\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+    def test_insufficient_columns(self, tmp_path):
+        """parse_tsv exits with code 1 when row has fewer than 2 columns."""
+        tsv_file = tmp_path / "bad_columns.tsv"
+        tsv_file.write_text("Title\tArtist\nOnly One Column\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+    def test_empty_title(self, tmp_path):
+        """parse_tsv exits with code 1 when title is empty."""
+        tsv_file = tmp_path / "empty_title.tsv"
+        tsv_file.write_text("Title\tArtist\n\tQueen\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+    def test_empty_artist(self, tmp_path):
+        """parse_tsv exits with code 1 when artist is empty."""
+        tsv_file = tmp_path / "empty_artist.tsv"
+        tsv_file.write_text("Title\tArtist\nBohemian Rhapsody\t\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+    def test_whitespace_only_fields(self, tmp_path):
+        """parse_tsv exits with code 1 when fields contain only whitespace."""
+        tsv_file = tmp_path / "whitespace.tsv"
+        tsv_file.write_text("Title\tArtist\n   \tQueen\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_tsv(str(tsv_file))
+        assert exc_info.value.code == 1
+
+
+class TestParseTsvSuccess:
+    """Test successful parsing scenarios."""
+
+    def test_valid_tsv(self, tmp_path):
+        """parse_tsv returns list of (title, artist) tuples for valid input."""
+        tsv_file = tmp_path / "valid.tsv"
+        tsv_file.write_text(
+            "Title\tArtist\n"
+            "Bohemian Rhapsody\tQueen\n"
+            "Hotel California\tEagles\n"
+        )
+
+        result = parse_tsv(str(tsv_file))
+
+        assert result == [
+            ("Bohemian Rhapsody", "Queen"),
+            ("Hotel California", "Eagles"),
+        ]
+
+    def test_extra_columns_ignored(self, tmp_path):
+        """parse_tsv ignores columns beyond Title and Artist."""
+        tsv_file = tmp_path / "extra_cols.tsv"
+        tsv_file.write_text(
+            "Title\tArtist\tAlbum\tYear\n"
+            "Imagine\tJohn Lennon\tImagine\t1971\n"
+        )
+
+        result = parse_tsv(str(tsv_file))
+
+        assert result == [("Imagine", "John Lennon")]
+
+    def test_whitespace_trimmed(self, tmp_path):
+        """parse_tsv strips leading/trailing whitespace from title and artist."""
+        tsv_file = tmp_path / "whitespace.tsv"
+        tsv_file.write_text(
+            "Title\tArtist\n"
+            "  Thriller  \t  Michael Jackson  \n"
+        )
+
+        result = parse_tsv(str(tsv_file))
+
+        assert result == [("Thriller", "Michael Jackson")]
+
+    def test_multiple_tracks(self, tmp_path):
+        """parse_tsv handles multiple tracks correctly."""
+        tsv_file = tmp_path / "multiple.tsv"
+        tsv_file.write_text(
+            "Title\tArtist\n"
+            "Track 1\tArtist A\n"
+            "Track 2\tArtist B\n"
+            "Track 3\tArtist C\n"
+        )
+
+        result = parse_tsv(str(tsv_file))
+
+        assert result == [
+            ("Track 1", "Artist A"),
+            ("Track 2", "Artist B"),
+            ("Track 3", "Artist C"),
+        ]

--- a/tests/test_score_track_match.py
+++ b/tests/test_score_track_match.py
@@ -1,0 +1,185 @@
+"""Tests for score_track_match() function."""
+
+import pytest
+
+from spotify_playlist import score_track_match, KARAOKE_KEYWORDS
+
+
+class TestScoreTrackMatchScoring:
+    """Test the scoring logic in score_track_match()."""
+
+    def test_exact_match_high_popularity(self, mock_spotify_track):
+        """Exact match with max popularity scores 80 points (40 artist + 30 title + 10 popularity)."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Queen",
+            popularity=100
+        )
+
+        score, name, artist = score_track_match(track, "Bohemian Rhapsody", "Queen")
+
+        assert score == pytest.approx(80.0, abs=0.1)
+        assert name == "Bohemian Rhapsody"
+        assert artist == "Queen"
+
+    def test_partial_artist_match(self, mock_spotify_track):
+        """Partial artist name match reduces artist score component."""
+        track = mock_spotify_track(
+            name="Imagine",
+            artist="John Lennon",
+            popularity=50
+        )
+
+        score_full, _, _ = score_track_match(track, "Imagine", "John Lennon")
+        score_partial, _, _ = score_track_match(track, "Imagine", "Lennon")
+
+        # Partial match should score lower than full match
+        assert score_partial < score_full
+
+    def test_zero_popularity(self, mock_spotify_track):
+        """Track with zero popularity scores 70 points (40 artist + 30 title + 0 popularity)."""
+        track = mock_spotify_track(
+            name="Test Song",
+            artist="Test Artist",
+            popularity=0
+        )
+
+        score, _, _ = score_track_match(track, "Test Song", "Test Artist")
+
+        assert score == pytest.approx(70.0, abs=0.1)
+
+    def test_case_insensitive_matching(self, mock_spotify_track):
+        """Matching is case-insensitive for both title and artist."""
+        track = mock_spotify_track(
+            name="BOHEMIAN RHAPSODY",
+            artist="QUEEN",
+            popularity=50
+        )
+
+        score, _, _ = score_track_match(track, "bohemian rhapsody", "queen")
+
+        assert score >= 70
+
+
+class TestScoreTrackMatchKaraokePenalty:
+    """Test karaoke keyword detection and penalty."""
+
+    def test_karaoke_in_title(self, mock_spotify_track):
+        """Karaoke keyword in title applies -50 penalty."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody (Karaoke Version)",
+            artist="Queen",
+            popularity=50
+        )
+
+        score, _, _ = score_track_match(track, "Bohemian Rhapsody", "Queen")
+
+        # Score should be significantly reduced (possibly negative)
+        assert score < 30
+
+    def test_karaoke_in_artist(self, mock_spotify_track):
+        """Karaoke keyword in artist name applies -50 penalty."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Karaoke Kings",
+            popularity=50
+        )
+
+        score, _, _ = score_track_match(track, "Bohemian Rhapsody", "Queen")
+
+        assert score < 30
+
+    def test_karaoke_in_album(self, mock_spotify_track):
+        """Karaoke keyword in album name applies -50 penalty."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Queen",
+            album="Karaoke Hits Vol 1",
+            popularity=50
+        )
+
+        score, _, _ = score_track_match(track, "Bohemian Rhapsody", "Queen")
+
+        assert score < 30
+
+    def test_cover_keyword_detected(self, mock_spotify_track):
+        """'cover' keyword also triggers penalty."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody (Cover)",
+            artist="Some Band",
+            popularity=50
+        )
+
+        score, _, _ = score_track_match(track, "Bohemian Rhapsody", "Queen")
+
+        assert score < 30
+
+    def test_all_karaoke_keywords_are_checked(self):
+        """Verify KARAOKE_KEYWORDS constant contains expected keywords."""
+        expected_keywords = {
+            "karaoke", "instrumental", "backing track", "cover",
+            "tribute", "in the style of", "made famous by",
+            "originally performed", "sing along", "minus one"
+        }
+        assert KARAOKE_KEYWORDS == expected_keywords
+
+
+class TestScoreTrackMatchEdgeCases:
+    """Test edge cases and defensive handling."""
+
+    def test_missing_artists_array(self):
+        """Handles track with missing artists array gracefully."""
+        track = {
+            "id": "abc123",
+            "name": "Test Song",
+            "artists": None,
+            "album": {"name": "Test Album"},
+            "popularity": 50
+        }
+
+        score, name, artist = score_track_match(track, "Test Song", "Test Artist")
+
+        assert artist == ""
+        assert name == "Test Song"
+        assert score < 40
+
+    def test_empty_artists_array(self):
+        """Handles track with empty artists array gracefully."""
+        track = {
+            "id": "abc123",
+            "name": "Test Song",
+            "artists": [],
+            "album": {"name": "Test Album"},
+            "popularity": 50
+        }
+
+        score, name, artist = score_track_match(track, "Test Song", "Test Artist")
+
+        assert artist == ""
+        assert score < 40
+
+    def test_missing_album(self):
+        """Handles track with missing album field gracefully."""
+        track = {
+            "id": "abc123",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "popularity": 50
+        }
+
+        score, name, artist = score_track_match(track, "Test Song", "Test Artist")
+
+        assert score >= 70
+
+    def test_missing_popularity(self):
+        """Handles track with missing popularity field, defaults to 0."""
+        track = {
+            "id": "abc123",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "album": {"name": "Test Album"}
+        }
+
+        score, name, artist = score_track_match(track, "Test Song", "Test Artist")
+
+        assert score == pytest.approx(70.0, abs=0.1)

--- a/tests/test_search_track.py
+++ b/tests/test_search_track.py
@@ -1,0 +1,221 @@
+"""Tests for search_track() function and related helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import spotipy
+
+from spotify_playlist import search_track, _execute_search, _find_best_match
+
+
+class TestSearchTrackTwoPassStrategy:
+    """Test the two-pass search strategy."""
+
+    def test_both_searches_executed(self, mock_spotify_track, mock_search_response):
+        """Both search queries are executed."""
+        track1 = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Queen",
+            track_id="track1",
+            popularity=80
+        )
+        track2 = mock_spotify_track(
+            name="Bohemian Rhapsody - Remastered",
+            artist="Queen",
+            track_id="track2",
+            popularity=70
+        )
+
+        mock_sp = MagicMock()
+        # First query returns track1, second returns track2
+        mock_sp.search.side_effect = [
+            mock_search_response([track1]),
+            mock_search_response([track2])
+        ]
+
+        result = search_track(mock_sp, "Bohemian Rhapsody", "Queen")
+
+        assert mock_sp.search.call_count == 2
+        # First call uses field specifiers
+        first_query = mock_sp.search.call_args_list[0][1]["q"]
+        assert "track:" in first_query and "artist:" in first_query
+        # Second call is plain text
+        second_query = mock_sp.search.call_args_list[1][1]["q"]
+        assert "track:" not in second_query
+
+    def test_best_match_selected(self, mock_spotify_track, mock_search_response):
+        """Best scored track is returned from all candidates."""
+        low_score_track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Some Cover Band",
+            track_id="low",
+            popularity=20
+        )
+        high_score_track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Queen",
+            track_id="high",
+            popularity=90
+        )
+
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = [
+            mock_search_response([low_score_track]),
+            mock_search_response([high_score_track])
+        ]
+
+        track_id, score, title, artist = search_track(mock_sp, "Bohemian Rhapsody", "Queen")
+
+        assert track_id == "high"
+        assert artist == "Queen"
+
+
+class TestSearchTrackDuplicateFiltering:
+    """Test duplicate track filtering."""
+
+    def test_duplicate_tracks_filtered(self, mock_spotify_track, mock_search_response):
+        """Same track ID appearing in both searches is only scored once."""
+        track = mock_spotify_track(
+            name="Bohemian Rhapsody",
+            artist="Queen",
+            track_id="same_id",
+            popularity=80
+        )
+
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = [
+            mock_search_response([track]),
+            mock_search_response([track])
+        ]
+
+        track_id, score, title, artist = search_track(mock_sp, "Bohemian Rhapsody", "Queen")
+
+        assert track_id == "same_id"
+        assert title == "Bohemian Rhapsody"
+
+
+class TestSearchTrackNoResults:
+    """Test handling when no results are found."""
+
+    def test_no_results_from_either_search(self, mock_search_response):
+        """Returns None tuple when neither search finds results."""
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = [
+            mock_search_response([]),
+            mock_search_response([])
+        ]
+
+        track_id, score, title, artist = search_track(mock_sp, "Nonexistent Song", "Unknown Artist")
+
+        assert track_id is None
+        assert score == 0
+        assert title is None
+        assert artist is None
+
+    def test_all_results_below_threshold(self, mock_spotify_track, mock_search_response):
+        """Returns None when all candidates score <= 0 (e.g., karaoke tracks)."""
+        karaoke_track = mock_spotify_track(
+            name="Test Song (Karaoke Version)",
+            artist="Karaoke Band",
+            track_id="karaoke",
+            popularity=50
+        )
+
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = [
+            mock_search_response([karaoke_track]),
+            mock_search_response([])
+        ]
+
+        track_id, score, title, artist = search_track(mock_sp, "Test Song", "Original Artist")
+
+        assert track_id is None
+
+
+class TestSearchTrackErrorHandling:
+    """Test error handling during search."""
+
+    def test_first_search_fails_continues_to_second(
+        self, mock_spotify_track, mock_search_response, capsys
+    ):
+        """When first search fails, second search still executes."""
+        track = mock_spotify_track(
+            name="Test Song",
+            artist="Test Artist",
+            track_id="found",
+            popularity=80
+        )
+
+        mock_sp = MagicMock()
+        # First search raises exception, second succeeds
+        mock_sp.search.side_effect = [
+            spotipy.SpotifyException(http_status=500, code=-1, msg="Server error"),
+            mock_search_response([track])
+        ]
+
+        track_id, score, title, artist = search_track(mock_sp, "Test Song", "Test Artist")
+
+        # Should find track from second search
+        assert track_id == "found"
+
+        # Error should be logged
+        captured = capsys.readouterr()
+        assert "Spotify API error" in captured.err
+
+
+class TestExecuteSearch:
+    """Test the _execute_search helper function."""
+
+    def test_returns_track_items(self, mock_spotify_track, mock_search_response):
+        """Returns items array from search response."""
+        track = mock_spotify_track(name="Test", artist="Artist", track_id="123")
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = mock_search_response([track])
+
+        result = _execute_search(mock_sp, "test query", "Test")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "123"
+
+    def test_returns_empty_list_on_error(self, capsys):
+        """Returns empty list when Spotify API raises exception."""
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = spotipy.SpotifyException(
+            http_status=429, code=-1, msg="Rate limited"
+        )
+
+        result = _execute_search(mock_sp, "test query", "Test")
+
+        assert result == []
+
+
+class TestFindBestMatch:
+    """Test the _find_best_match helper function."""
+
+    def test_returns_highest_scored_track(self, mock_spotify_track):
+        """Returns track with highest score."""
+        low = mock_spotify_track(name="Wrong Song", artist="Wrong Artist", track_id="low", popularity=90)
+        high = mock_spotify_track(name="Right Song", artist="Right Artist", track_id="high", popularity=80)
+
+        result = _find_best_match([low, high], "Right Song", "Right Artist")
+
+        assert result[0] == "high"
+
+    def test_returns_none_for_empty_candidates(self):
+        """Returns None tuple for empty candidate list."""
+        result = _find_best_match([], "Song", "Artist")
+
+        assert result == (None, 0, None, None)
+
+    def test_returns_none_when_all_scores_zero_or_below(self, mock_spotify_track):
+        """Returns None when all candidates have score <= 0."""
+        karaoke = mock_spotify_track(
+            name="Song (Karaoke)",
+            artist="Karaoke Kings",
+            track_id="karaoke",
+            popularity=50
+        )
+
+        result = _find_best_match([karaoke], "Song", "Original Artist")
+
+        assert result == (None, 0, None, None)


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `parse_tsv()`, `score_track_match()`, and `search_track()` functions
- Create test infrastructure with pytest and shared fixtures for mocking Spotify API responses
- 35 tests covering error handling, scoring logic, and two-pass search strategy

## Test Coverage

| Function | Tests | Coverage |
|----------|-------|----------|
| `parse_tsv()` | 11 | Error paths + valid parsing |
| `score_track_match()` | 14 | Scoring logic + karaoke filtering |
| `search_track()` | 11 | Two-pass strategy + deduplication |

## Test plan

- [x] All 35 tests pass (`pytest tests/ -v`)
- [x] Tests use mocked Spotify API responses (no real API calls)

Closes #5